### PR TITLE
fix restock de producto al eliminarItem particular

### DIFF
--- a/app/Services/Ventas/ProductoVentaService.php
+++ b/app/Services/Ventas/ProductoVentaService.php
@@ -258,6 +258,15 @@ class ProductoVentaService implements ProductoVentaServiceInterface
                 return VentaResponse::warning('No puede eliminar el único item disponible');
             }
 
+            
+            // Restaurar stock si es contable
+            if ($producto->contable) {
+                $stockResponse = $this->stockService->actualizarStock($producto, 'restar', 1, $venta->sucursale_id);
+                if (!$stockResponse->success) {
+                    return VentaResponse::error('Error al restaurar stock: ' . $stockResponse->message);
+                }
+            }
+
             // Restaurar stock de adicionales
             foreach ($array[$posicion] as $adic) {
                 $adicional = Adicionale::where('nombre', key($adic))->first();


### PR DESCRIPTION
Cambios relevantes en ProductoVentaService.php:

- Inclusion de restauracion de stock para productos contables mediante stockService->actualizarStock en la funcion eliminarItem, utlizando un parametro "cantidad" de 1.

Este cambio se vio necesario dado a que la eliminacion de items producto en la vista venta de la administracion no realizaba el restockeado correspondiente.